### PR TITLE
chore: correct the project url in cliff config

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -46,7 +46,7 @@ footer = """
 trim = true
 # postprocessors
 postprocessors = [
-    { pattern = '\$REPO', replace = "https://github.com/dfyuik/template" }, # replace repository URL
+    { pattern = '\$REPO', replace = "https://github.com/dfyuik/01-rcli" }, # replace repository URL
 ]
 
 [git]


### PR DESCRIPTION
chore: correct the project url in cliff config